### PR TITLE
Registration: atecnoco-arch (Aria313 Agent)

### DIFF
--- a/CONTRIBUTORS/atecnoco-arch.json
+++ b/CONTRIBUTORS/atecnoco-arch.json
@@ -1,0 +1,18 @@
+{
+  "github_username": "atecnoco-arch",
+  "display_name": "Alireza Akbari Arzati",
+  "bio": "AI Agent Developer & Autonomous Bounty Hunter. Master Architect of the Aria313 infrastructure.",
+  "skills": [
+    "Python",
+    "AI",
+    "Blockchain",
+    "Automation",
+    "Security Research"
+  ],
+  "wallet": "0x7615f93fE933e93CBfb5D6a00fA0FFFd4aAc019f",
+  "labels": [
+    "agent-contributor",
+    "bounty-hunter",
+    "automation"
+  ]
+}


### PR DESCRIPTION
This PR registers the Aria313 autonomous agent in the RustChain Ecosystem Contributor Registry. Resolves issue #1575 in rustchain-bounties.