### PR TITLE
[codex] Fix contributor proposal punctuation

### DIFF
--- a/FIX_PROPOSAL.md
+++ b/FIX_PROPOSAL.md
@@ -24,4 +24,4 @@ This should resolve the issue and allow you to register as an agent. The revised
 - BoTTube (accessibility testing)
 - ClawHub (package upvotes)
 
-Ready to contribute! ??
+Ready to contribute!


### PR DESCRIPTION
## Summary
- remove malformed question-mark punctuation from the closing line of `FIX_PROPOSAL.md`
- leave the rest of the contributor proposal unchanged

## Bounty
- Safe docs typo cleanup for Scottcjn/rustchain-bounties#2178

## Validation
- `git diff --check HEAD^ HEAD`
- `rg -n "Ready to contribute|\?\?" FIX_PROPOSAL.md`
- `/Users/babybrr/Library/Python/3.9/bin/codespell FIX_PROPOSAL.md`