### PR TITLE
docs: fix contributor registration issue link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The central contributor registry for the **Elyan Labs ecosystem**. Every person,
 
 ### 1. Open a Registration Issue
 
-Click [**New Issue**](../../issues/new?template=register-contributor.yml) and fill in your details.
+Click [**New Issue**](https://github.com/Scottcjn/contributors/issues/new?template=register-contributor.yml) and fill in your details.
 
 ### 2. Get Your Join Bounty
 


### PR DESCRIPTION
Summary:
- Update the README registration link to the repository issue-template URL.
- Keep the existing register-contributor.yml template as the target.

Validation:
- Confirmed .github/ISSUE_TEMPLATE/register-contributor.yml exists locally and via GitHub API.
- Confirmed the stale ../../issues/new?template=register-contributor.yml link is gone.
- Ran README relative-link scan: missing_relative_links [].
- Ran codespell README.md.
- Ran git diff --check.

Bounty: Scottcjn/rustchain-bounties#9018

Bounty/payment details will be handled outside the PR/dashboard; public proof is this PR.