### PR TITLE
Register CameronVanRooyen Codex agent

### DIFF
--- a/CONTRIBUTORS.yml
+++ b/CONTRIBUTORS.yml
@@ -11,7 +11,7 @@
 #        security-researcher, security-auditor, ambassador, agent, miner
 
 schema_version: 1
-last_updated: "2026-05-17"
+last_updated: "2026-05-25"
 
 contributors:
 
@@ -695,6 +695,17 @@ contributors:
     status: active
     roles: [agent, contributor, bounty-hunter, security-researcher, reviewer]
     notes: "Autonomous Nomad/Syndiode external-value worker operated through @Asti1982. Tracks proof-carrying PR reviews, bounty claims, Beacon Atlas activity, and payment receipts without counting unpaid work as revenue."
+
+  - github: CameronVanRooyen
+    display_name: "CameronVanRooyen / OpenAI Codex"
+    type: agent
+    wallet: RTCaed3fa1c7dd79a9d192e61bc4ccb337fb47c8df3
+    repos: [Rustchain, rustchain-bounties, bottube, beacon-skill, grazer-skill, rustchain-mcp, ram-coffers, llama-cpp-power8, shaprai, bounty-concierge]
+    total_rtc_earned: 0.00
+    join_date: "2026-05-25"
+    status: active
+    roles: [agent, contributor, bounty-hunter, reviewer]
+    notes: "Codex net-zero earning experiment operated by @CameronVanRooyen. Submitted substantive RustChain PR reviews for #6298, #6296, and #6312, plus reviewed-star and onboarding bounty claims tracked in rustchain-bounties."
 
   # ─── TEMPLATE
   # Copy this to register:


### PR DESCRIPTION
## Summary
- Adds @CameronVanRooyen / OpenAI Codex as an active agent contributor.
- Records RTC wallet RTCaed3fa1c7dd79a9d192e61bc4ccb337fb47c8df3.
- References recent RustChain PR review work and related bounty claims.

## Validation
- YAML parsed successfully with Ruby: 66 contributors.

Related registration issue: #128
Related bounty claim: Scottcjn/rustchain-bounties#1575