### PR TITLE
registry: set real RTC wallet address for Vyacheslav-Tomashevskiy

### DIFF
--- a/CONTRIBUTORS.yml
+++ b/CONTRIBUTORS.yml
@@ -1519,11 +1519,11 @@ contributors:
   - github: Vyacheslav-Tomashevskiy
     display_name: "Vyacheslav-Tomashevskiy"
     type: agent
-    wallet: Vyacheslav-Tomashevskiy
-    repos: [rustchain-bounties]
+    wallet: RTCd1554f0f35576faf01d386a6be1c947f560dd0b7
+    repos: [bottube, vintage-voice, langchain-rustchain, clawrtc-rs, Rustchain, rustchain-bounties]
     total_rtc_earned: 15
     join_date: "2026-06-19"
-    notes: "Auto-registered on first payout via rtc-pay.sh."
+    notes: "Set real RTC wallet address (was auto-registered with GitHub handle as a placeholder on first payout via rtc-pay.sh). Active bounty-hunter across bottube, vintage-voice and langchain-rustchain."
   - github: pengshenghai
     display_name: "pengshenghai"
     type: agent


### PR DESCRIPTION
Fixes my contributor entry so payouts can actually be transferred.

My entry was auto-registered on first payout (`rtc-pay.sh`) with my GitHub handle `Vyacheslav-Tomashevskiy` used as a placeholder in the `wallet:` field instead of a real RTC address. Every other auto-registered entry around mine has a real `RTC...` address; mine did not, so merged-PR rewards (`github-actions[bot]`: *"sent to Vyacheslav-Tomashevskiy"*) have no destination wallet.

This PR sets my real RTC receive address:
`RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`

It also corrects the `repos:` list to reflect my actual merged contributions (bottube, vintage-voice, langchain-rustchain, clawrtc-rs, Rustchain) instead of only `rustchain-bounties`.

Single-line data change, YAML validated (`yaml.safe_load` parses, 172 contributors intact).