### PR TITLE
Fix broken balance-check command and stale stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,16 +77,17 @@ Browse open bounties at [rustchain-bounties](https://github.com/Scottcjn/rustcha
 
 ## Ecosystem Stats
 
-- **65+ unique GitHub contributors** across 6 repos
-- **218 unique RTC wallet holders** in the bounty ledger
-- **23,600+ RTC paid** (~$2,360 USD at $0.10/RTC)
-- **718 bounty transactions** processed
+Live figures are published at [rustchain.org/payouts.json](https://rustchain.org/payouts.json). Snapshot as of 2026-07-25:
+
+- **72,499+ RTC paid** to **1,124 unique recipients**
+- **3,634 payout transactions** processed
+- **1,528 wallet holders** on chain (live at [rustchain.org/api/tokenomics](https://rustchain.org/api/tokenomics))
 
 ## Verify On-Chain
 
 ```bash
 # Check any wallet balance
-curl -sk "https://rustchain.org/api/balance?wallet=YOUR_WALLET"
+curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET"
 
 # Block explorer
 # https://rustchain.org/explorer

--- a/llms.txt
+++ b/llms.txt
@@ -21,7 +21,7 @@
 - rustchain-bounties: Bounty tracking and RTC payout ledger.
 
 ## Token
-- RTC: RustChain native token. 1 RTC ≈ $0.10 USD. Mint on Solana: 12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X (wRTC)
+- RTC: RustChain native token. 1 RTC ≈ $0.15 USD (internal reference rate, live at rustchain.org/api/tokenomics). Mint on Solana: 12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X (wRTC)
 
 ## Contributor Types
 - human-contributor: Verified human contributor
@@ -69,16 +69,16 @@ Open a new issue at https://github.com/Scottcjn/contributors/issues/new?template
 Yes. The registry explicitly labels `agent-contributor` as a first-class contributor type. AI agents earn RTC on equal terms with humans.
 
 **What is RTC and how much is it worth?**
-RTC is RustChain's native token, approximately $0.10 USD per RTC. It's earned by contributing code, docs, security research, or community work.
+RTC is RustChain's native token. The internal reference rate is $0.15 USD per RTC (live rate at https://rustchain.org/api/tokenomics). It's earned by contributing code, docs, security research, or community work.
 
 **How many contributors are registered?**
-65+ unique GitHub contributors across 6 ecosystem repos, with 218 unique RTC wallet holders and 23,600+ RTC paid in bounties.
+As of 2026-07-25: 1,124 unique RTC recipients and 72,499+ RTC paid in bounties. Live figures at https://rustchain.org/payouts.json.
 
 **What repos are tracked?**
 RustChain, BoTTube, beacon-skill, grazer-skill, rustchain-mcp, and rustchain-bounties.
 
 **Can I verify bounty payouts on-chain?**
-Yes. Use `curl -sk "https://rustchain.org/api/balance?wallet=YOUR_WALLET"` or visit the block explorer.
+Yes. Use `curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET"` or visit the block explorer.
 
 **What contributor types exist?**
 Human, bot, agent, founder, bounty-hunter, security-researcher, ambassador, and miner.


### PR DESCRIPTION
The "Verify On-Chain" command is the exact thing a skeptic runs to check the project is real, and it 404s today.

- `https://rustchain.org/api/balance?wallet=X` returns 404 (curl, 2026-07-25).
- Working endpoint: `https://rustchain.org/wallet/balance?miner_id=X` returns 200 with `{"amount_rtc": ...}`. README and llms.txt now use it.
- Stats were frozen at 23,600+ RTC paid / 218 wallet holders / 718 transactions. Live figures from https://rustchain.org/payouts.json as of 2026-07-25: 72,499+ RTC to 1,124 recipients over 3,634 transactions. The section now links the live endpoints and datestamps the snapshot.
- Reference rate in llms.txt updated from $0.10 to $0.15 per the live https://rustchain.org/api/tokenomics.