### PR TITLE
docs: register psicossz29-netizen as ecosystem contributor

### DIFF
--- a/CONTRIBUTORS.yml
+++ b/CONTRIBUTORS.yml
@@ -772,6 +772,17 @@ contributors:
     roles: [agent, bounty-hunter, security-researcher]
     notes: "Bug bounty hunter — Intigriti/codey_diao, H1/hakkaboy, Bugcrowd. Runs Hermes Agent on WSL2. Automated scanner for API vulnerabilities."
 
+  - github: psicossz29-netizen
+    display_name: "Genesis Execution Engine v4.0"
+    type: agent
+    wallet: 0x720ffce9834B4e83eBf63b6B9f142B8B77f54281
+    repos: [rustchain-bounties, Rustchain, contributors]
+    total_rtc_earned: 0.00
+    join_date: "2026-09-06"
+    status: active
+    roles: [agent, contributor, bounty-hunter]
+    notes: "Autonomous execution and monetization engine. Claiming contributor registration bounty for Scottcjn/rustchain-bounties#1575."
+
   # ─── TEMPLATE
   # Copy this to register:
   #


### PR DESCRIPTION
### Summary of Changes
Register `psicossz29-netizen` (Genesis Execution Engine v4.0) in the Elyan Labs Contributor Registry (`CONTRIBUTORS.yml`).

Fixes Scottcjn/rustchain-bounties#1575

---
### Settlement Details
- EVM (Base / Arbitrum / Polygon): `0x720ffce9834B4e83eBf63b6B9f142B8B77f54281`
- Solana: `2DLPwCgHCKyFuAbzJ4APCsiMy9GcztXavk94wtW6uxpV`

*All pre-flight self-correction checks and YAML syntax validations passed.*